### PR TITLE
Add call to setuptools.find_packages() in setup.py to fix pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name             = "iris_sdk",
@@ -8,7 +8,7 @@ setup(
     maintainer       = "Bandwidth",
     url              = "https://github.com/scottbarstow/iris-python",
     license          = "MIT",
-    packages         = ["iris_sdk"],
+    packages         = find_packages(),
     long_description = "Python client library for IRIS / BBS API",
     classifiers = [
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
When installing this package using `pip install` without the `-e` (editable) option, several modules are missing from the installed package.

Because of line 11 in setup.py, which specifies `packages=["iris_sdk"]` the subdirectories of /iris_sdk are not included in the install.  The issue is resolved by replacing `["iris_sdk"]` with `find_packages()` from setuptools.

