### PR TITLE
Consumers should be able to create Order Subscriptions

### DIFF
--- a/iris_sdk/models/maps/subscription.py
+++ b/iris_sdk/models/maps/subscription.py
@@ -8,3 +8,4 @@ class SubscriptionMap(BaseMap):
     order_id = None
     order_type = None
     email_subscription = None
+    callback_subscription = None

--- a/iris_sdk/utils/strings.py
+++ b/iris_sdk/utils/strings.py
@@ -7,6 +7,8 @@ class Converter(object):
     """String case conversions"""
 
     def to_camelcase(self, string):
+        if string.upper() == 'URL':
+            return 'URL'
         str = sub(r'_([a-zA-Z])', lambda m: m.group(1).upper(), string)
         return str[0].upper() + str[1:]
 

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -28,7 +28,9 @@ class ClassStringsConverterTest(TestCase):
             ("foo_bar", "FooBar"),
             ("FooBar", "FooBar"),
             ("_foo_bar", "FooBar"),
-            ("_foo__bar", "Foo_Bar")]
+            ("_foo__bar", "Foo_Bar"),
+            # Url needs to be treated as special for XML serialization
+            ('url', 'URL')]
 
         for input, output in tests:
             self.assertEqual(self._converter.to_camelcase(input), output)

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -67,6 +67,30 @@ class ClassSubscriptionsTest(TestCase):
 
             self.assertEqual(subscription.id, "777")
 
+    def test_subscriptions_create_for_orders(self):
+
+        subscription = self._account.subscriptions.create({
+            "order_type": "orders",
+            "callback_subscription": {
+                "url": "https://someurl",
+                "expiry": "86400",
+            }
+        }, False)
+
+        self.assertEqual(subscription.order_type, "orders")
+        self.assertEqual(subscription.callback_subscription.url, "https://someurl")
+        self.assertEqual(subscription.callback_subscription.expiry, '86400')
+
+        with requests_mock.Mocker() as m:
+
+            url = self._client.config.url + \
+                self._account.subscriptions.get_xpath()
+            m.post(url, headers={"location": ".../777"})
+
+            subscription.save()
+
+            self.assertEqual(subscription.id, "777")
+
     def test_subscriptions_list(self):
 
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
The CallbackSubscription object wasn't being serialized at all, and the 'url' attribute must be in all uppercase when serialized to xml