### PR TITLE
Reset the ImportTnChecker on every call

### DIFF
--- a/iris_sdk/models/import_tn_checker.py
+++ b/iris_sdk/models/import_tn_checker.py
@@ -18,7 +18,7 @@ class ImportTnChecker(BaseResource, ImportTnCheckerData):
     _xpath = XPATH_IMPORTTN_CHECKER
 
     def __call__(self, numbers):
-        # self.clear()
+        self.clear()
         self.telephone_numbers.items.extend(numbers)
         return self._post_data(ImportTnCheckerResponse())
 


### PR DESCRIPTION
The list of phone numbers was being retained, potentially resulting in
duplicates with every call.

```
phone_num = '{a legit number}'

In [9]: account.import_tn_checker(numbers=[phone_num'])
Out[9]: <iris_sdk.models.import_tn_checker_response.ImportTnCheckerResponse at 0x112d60280>

In [10]: account.import_tn_checker(numbers=[phone_num])
---------------------------------------------------------------------------
RestError                                 Traceback (most recent call last)
...
RestError: 5093 Iris error: Order cannot contain duplicate telephone numbers
```